### PR TITLE
Ensure object catalog loads on client

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -29,9 +29,14 @@ local function loadObjectsFromXML()
 
     local catalog = xmlFindChild(xml, "catalog", 0)
     if not catalog then
-        outputChatBox("Invalid objects.xml format", 255, 0, 0)
-        xmlUnloadFile(xml)
-        return
+        -- handle case where <catalog> is the root node
+        if xmlNodeGetName(xml) == "catalog" then
+            catalog = xml
+        else
+            outputChatBox("Invalid objects.xml format", 255, 0, 0)
+            xmlUnloadFile(xml)
+            return
+        end
     end
 
     for _, group in ipairs(xmlNodeGetChildren(catalog)) do
@@ -287,7 +292,7 @@ local function updateTransformSliders()
 end
 
 -- Functions
-local function removeAttachedObject(obj
+local function removeAttachedObject(obj)
     if not isElement(obj) then return end
     triggerServerEvent("removeAttachedObject", resourceRoot, obj)
     local index = getAttachedObjectIndex(obj)

--- a/meta.xml
+++ b/meta.xml
@@ -3,6 +3,7 @@
     <info author="Generated" version="3.0" name="Vehicle Object Attacher Full" type="script"/>
     <script src="client.lua" type="client"/>
     <script src="server.lua" type="server"/>
+    <file src="objects.xml"/>
     <oop>true</oop>
     <min_mta_version client="1.5.2" server="1.5.2"/>
     <!-- Required function -->


### PR DESCRIPTION
## Summary
- add objects.xml to `meta.xml` so clients receive it
- handle case where objects.xml root is `<catalog>` in Lua loader

## Testing
- `luac -p client.lua && echo client_OK`
- `luac -p server.lua && echo server_OK`


------
https://chatgpt.com/codex/tasks/task_e_68537e22d9c0832faa956c5f63053adf