### PR TITLE
Fix F7 binding by defining functions early

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -8,6 +8,10 @@ local currentPage = 1
 local cachedObjects = {}
 local errorMessages = {}
 
+-- Forward declarations
+local updateObjectList
+local toggleWindow
+
 -- Preview object variables
 local previewObject = nil
 local isPreviewMode = false
@@ -115,7 +119,7 @@ for i, label in ipairs(labels) do
 end
 
 -- Functions
-local function updateObjectList()
+updateObjectList = function()
     guiGridListClear(objectList)
     local startIndex = (currentPage - 1) * ITEMS_PER_PAGE + 1
     local endIndex = math.min(startIndex + ITEMS_PER_PAGE - 1, #cachedObjects)
@@ -532,7 +536,7 @@ addEventHandler("onAttachmentError", resourceRoot, function(message)
     outputChatBox(message, 255, 0, 0)
 end)
 
-local function toggleWindow()
+toggleWindow = function()
     local veh = getPedOccupiedVehicle(localPlayer)
     if not veh then
         outputChatBox("You need to be in a vehicle to use this menu.", 255, 0, 0)


### PR DESCRIPTION
## Summary
- declare `updateObjectList` and `toggleWindow` early so they exist when the resource start handler is defined
- assign these functions later so binding F7 works

## Testing
- `luac -p client.lua`
- `luac -p server.lua`


------
https://chatgpt.com/codex/tasks/task_e_685382927f64832f9e302adbef93263b