### PR TITLE
Fix object list IDs

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -59,10 +59,12 @@ end
 
 -- Cache valid objects
 addEventHandler("onClientResourceStart", resourceRoot, function()
-    for i = 1000, 20000 do
+    -- Include lower IDs so XML objects display with valid names
+    for i = 300, 20000 do
         local modelName = engineGetModelNameFromID(i)
         if modelName then
-            table.insert(cachedObjects, {id = i, name = modelName})
+            -- Use the same key for the model ID as objects loaded from XML
+            table.insert(cachedObjects, {model = i, name = modelName})
             debugOutput("Cached object: ID=" .. i .. ", Name=" .. modelName)
         end
     end

--- a/server.lua
+++ b/server.lua
@@ -5,7 +5,8 @@ local vehicleAttachments = {} -- Track attachments per vehicle
 
 -- Initialize valid object IDs
 addEventHandler("onResourceStart", resourceRoot, function()
-    for i = 1000, 20000 do
+    -- Include lower model IDs so objects from XML are accepted
+    for i = 300, 20000 do
         if engineGetModelNameFromID(i) then
             VALID_OBJECT_IDS[i] = true
         end


### PR DESCRIPTION
## Summary
- expand valid model ID range to include small IDs loaded from XML
- store cached object IDs using the `model` field
- cache object names starting from model ID 300

## Testing
- `luac -p client.lua` *(client-ok)*
- `luac -p server.lua` *(server-ok)*

------
https://chatgpt.com/codex/tasks/task_e_685386dedf14832f95a54d05cd9c8a8b