### PR TITLE
Fix object attachment ID rejection

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -59,10 +59,12 @@ end
 
 -- Cache valid objects
 addEventHandler("onClientResourceStart", resourceRoot, function()
-    for i = 1000, 20000 do
+    -- Include lower IDs so XML objects display with valid names
+    for i = 300, 20000 do
         local modelName = engineGetModelNameFromID(i)
         if modelName then
-            table.insert(cachedObjects, {id = i, name = modelName})
+            -- Use the same key for the model ID as objects loaded from XML
+            table.insert(cachedObjects, {model = i, name = modelName})
             debugOutput("Cached object: ID=" .. i .. ", Name=" .. modelName)
         end
     end
@@ -533,7 +535,7 @@ end)
 
 addEvent("onAttachmentError", true)
 addEventHandler("onAttachmentError", resourceRoot, function(message)
-    outputChatBox(message, 255, 0, 0)
+    outputChatBox("Attachment Error: " .. tostring(message), 255, 0, 0)
 end)
 
 toggleWindow = function()

--- a/server.lua
+++ b/server.lua
@@ -1,11 +1,24 @@
 -- Configuration
 local MAX_ATTACHMENTS_PER_VEHICLE = 10
-local VALID_OBJECT_IDS = {} -- Will be populated on resource start
+-- Cache of model IDs confirmed valid via engineGetModelNameFromID
+local VALID_OBJECT_IDS = {}
+
+-- Helper to lazily validate model IDs
+local function ensureValidModel(id)
+    if type(id) ~= "number" then return false end
+    if VALID_OBJECT_IDS[id] then return true end
+    if engineGetModelNameFromID(id) then
+        VALID_OBJECT_IDS[id] = true
+        return true
+    end
+    return false
+end
 local vehicleAttachments = {} -- Track attachments per vehicle
 
 -- Initialize valid object IDs
 addEventHandler("onResourceStart", resourceRoot, function()
-    for i = 1000, 20000 do
+    -- Include lower model IDs so objects from XML are accepted
+    for i = 300, 20000 do
         if engineGetModelNameFromID(i) then
             VALID_OBJECT_IDS[i] = true
         end
@@ -47,7 +60,7 @@ end)
 
 addEvent("attachObjectToVehicle", true)
 addEventHandler("attachObjectToVehicle", resourceRoot, function(veh, modelID, offset, rotation)
-    if not isElement(veh) or type(modelID) ~= "number" or not VALID_OBJECT_IDS[modelID] then
+    if not isElement(veh) or not ensureValidModel(modelID) then
         triggerClientEvent(client, "onAttachmentError", resourceRoot, "Invalid vehicle or model ID")
         return
     end


### PR DESCRIPTION
## Summary
- add lazy server-side ID validation instead of relying on a prefilled cache
- use helper to confirm a model ID is valid via `engineGetModelNameFromID`
- show clearer attachment errors on the client

## Testing
- `luac -p client.lua`
- `luac -p server.lua`


------
https://chatgpt.com/codex/tasks/task_e_685386dedf14832f95a54d05cd9c8a8b